### PR TITLE
Add fish support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Go's package management expects that all go source files and packages will exist
 - Isolates dependencies from other projects.
 - Does not interfere with any `go` command functionality.
 - Written in Go, installable with `go get`.
-- Support POSIX compliant shells like Bash and ZSH, but now also Fish :)
+- Supports POSIX compliant shells like Bash and ZSH, but now also Fish :)
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Go's package management expects that all go source files and packages will exist
 - Isolates dependencies from other projects.
 - Does not interfere with any `go` command functionality.
 - Written in Go, installable with `go get`.
+- Support POSIX compliant shells like Bash and ZSH, but now also Fish :)
 
 ## Quick start
 

--- a/init.go
+++ b/init.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/user"
+	"path"
 	"path/filepath"
 	"text/template"
 )
@@ -180,6 +181,7 @@ func (task *InitTask) Run() error {
 
 // writeScript writes the goenv activate script.
 func (task *InitTask) writeScript() error {
+	var isFish = path.Base(os.Getenv("SHELL")) == "fish"
 
 	err := os.MkdirAll(filepath.Dir(task.ScriptPath), os.ModeDir|0755)
 
@@ -188,7 +190,11 @@ func (task *InitTask) writeScript() error {
 	}
 
 	scriptTemplate := template.New("test")
-	scriptTemplate, err = scriptTemplate.Parse(script)
+	if isFish {
+		scriptTemplate, err = scriptTemplate.Parse(scriptFish)
+	} else {
+		scriptTemplate, err = scriptTemplate.Parse(script)
+	}
 
 	if err != nil {
 		return err

--- a/init.go
+++ b/init.go
@@ -57,7 +57,7 @@ set -x GOENV_OLDPATH $PATH
 set -x GOPATH {{.GoPath}}
 set -x PATH $GOPATH/bin $PATH
 
-mkdir -p $(dirname $GOPATH/src/{{.ImportPath}})
+mkdir -p (dirname $GOPATH/src/{{.ImportPath}})
 rm -f $GOPATH/src/{{.ImportPath}}
 ln -s {{.ProjectPath}} $GOPATH/src/{{.ImportPath}}
 
@@ -65,10 +65,12 @@ function deactivate
 	set -x GOPATH $GOENV_OLDGOPATH
 	set -x PATH $GOENV_OLDPATH
 
-	set -e GOENV GOENV_OLDPS1 GOENV_OLDPATH GOENV_OLDGOPATH
+	set -e GOENV
+	set -e GOENV_OLDPS1
+	set -e GOENV_OLDPATH
+	set -e GOENV_OLDGOPATH
 	functions --erase deactivate
 end
-funcsave deactivate
 `
 
 var initCommand = Command{

--- a/init.go
+++ b/init.go
@@ -42,6 +42,34 @@ deactivate() {
 }
 `
 
+const scriptFish = `
+# This file must be used with "source activate" or ". activate"
+
+if test -n "$GOENV"
+	deactivate
+end
+
+set -x GOENV {{.ProjectName}}
+set -x GOENV_OLDGOPATH $GOPATH
+set -x GOENV_OLDPATH $PATH
+
+set -x GOPATH {{.GoPath}}
+set -x PATH $GOPATH/bin $PATH
+
+mkdir -p $(dirname $GOPATH/src/{{.ImportPath}})
+rm -f $GOPATH/src/{{.ImportPath}}
+ln -s {{.ProjectPath}} $GOPATH/src/{{.ImportPath}}
+
+function deactivate
+	set -x GOPATH $GOENV_OLDGOPATH
+	set -x PATH $GOENV_OLDPATH
+
+	set -e GOENV GOENV_OLDPS1 GOENV_OLDPATH GOENV_OLDGOPATH
+	functions --erase deactivate
+end
+funcsave deactivate
+`
+
 var initCommand = Command{
 	Name:  "init",
 	Short: "initialize a goenv",


### PR DESCRIPTION
Currently goenv does not support the Fish shell, and it has only been possible to use with silly workarounds and plugins, when the solution is fairly simple: a separate init script for fish that does what the default one does except in a way fish understands.