### PR TITLE
add missing `init` command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ go get github.com/crsmithdev/goenv
 Within your project directory, create a goenv:
 
 ```
-goenv github.com/me/myproject
+goenv init github.com/me/myproject
 ```
 
 Activate the goenv:


### PR DESCRIPTION
this seemed necessary for me; i didn't look too hard at whether I'd otherwise missed something, apologies if so

```
$ goenv env
goenv: unrecognized command env
Goenv provides isolated GOPATH environments for Go projects.

Usage:

    goenv [command] [arguments]

Commands:

    help     get help for a command
    init     initialize a goenv

Use "goenv help [command]" for command-specific information.

$ goenv init env
goenv: initializing...
goenv: wrote activation script at ./env/activate
goenv: done
```